### PR TITLE
Fix: LinkedIn polling immediate messaging after connection acceptance

### DIFF
--- a/backend/features/campaigns/services/unipileService.js
+++ b/backend/features/campaigns/services/unipileService.js
@@ -55,6 +55,9 @@ class UnipileService {
     async sendLinkedInMessage(employee, messageText, accountId, options = {}) {
         return this.message.sendLinkedInMessage(employee, messageText, accountId, options);
     }
+    async sendFirstLinkedInMessage(accountId, recipientProviderId, messageText, options = {}) {
+        return this.message.sendFirstLinkedInMessage(accountId, recipientProviderId, messageText, options);
+    }
     // Profile service methods
     async followLinkedInProfile(employee, accountId) {
         return this.profile.followLinkedInProfile(employee, accountId);


### PR DESCRIPTION
- LinkedInPollingService.js: Use followupMessage instead of connectionMessage for post-acceptance messages
- unipileService.js: Add missing sendFirstLinkedInMessage() method for immediate messaging
- LinkedInAccountStatusService.js: Enhanced webhook status mappings (DELETED/INVALID/REMOVED -> inactive)

Fixes issue where accepted connections were not receiving immediate messages due to:
1. Wrong message template being used (connectionMessage instead of followupMessage)
2. Missing sendFirstLinkedInMessage function in unipileService